### PR TITLE
Add installation script support for Kali Linux 2.0 (sana)

### DIFF
--- a/install-esteid.sh
+++ b/install-esteid.sh
@@ -46,8 +46,15 @@ test_sudo() {
 
 test_root() {
   if test `id -u` -eq 0; then
-    echo "You run this script as root. DO NOT RUN RANDOM SCRIPTS AS ROOT."
-    exit 2
+    echo "You ran this script as root. ARE YOU CERTAIN YOU KNOW WHAT YOU ARE DOING?"
+    select certain in Yes No; do
+      if [ "$certain" == "Yes" ]; then
+        alias sudo=""  # redefine sudo and allow execution as root
+        break
+      else
+        exit 2
+      fi
+    done
   fi
 }
 

--- a/install-esteid.sh
+++ b/install-esteid.sh
@@ -130,6 +130,16 @@ case $distro in
           ;;
       esac
       ;;
+   Kali)
+      case $codename in
+        sana) make_warn "Kali Linux 2.0 ($codename) is not officially supported"
+        add_repository trusty
+        ;;
+        *)
+          make_fail "Kali $release ($codename) is not officially supported"
+          ;;
+      esac
+      ;;
    *)
       make_fail "$distro is not supported :("
       ;;

--- a/install-esteid.sh
+++ b/install-esteid.sh
@@ -64,6 +64,14 @@ add_repository() {
   echo -e "# AUTOMATICALLY GENERATED\ndeb https://installer.id.ee/media/ubuntu/ $1 main" | sudo tee /etc/apt/sources.list.d/ria-repository.list
 }
 
+# Debian and Debian-based distros often lack apt-transport-https installation,
+# so we attempt to install it before fetching stuff from RIA HTTPS repo
+install_apt_transport_https() {
+  echo "### Installing possibly missing https support for APT (apt-get install apt-transport-https)"
+  # Debian lacks https support for apt, by default
+  sudo apt-get install apt-transport-https
+}
+
 make_install() {
   echo "Installing software (apt-get update && apt-get install estonianidcard)"
   sudo apt-get update
@@ -103,9 +111,7 @@ codename=`lsb_release -cs`
 case $distro in
    Debian)
       make_warn "Debian is not officially supported"
-      echo "### Installing possibly missing https support for APT (apt-get install apt-transport-https)"
-      # Debian lacks https support for apt, by default
-      sudo apt-get install apt-transport-https
+      install_apt_transport_https
       case $codename in
         wheezy)
           add_repository trusty
@@ -138,9 +144,11 @@ case $distro in
       esac
       ;;
    Kali)
+      make_warn "Kali Linux is not officially supported"
+      install_apt_transport_https
       case $codename in
-        sana) make_warn "Kali Linux 2.0 ($codename) is not officially supported"
-        add_repository trusty
+        sana)
+          add_repository trusty
         ;;
         *)
           make_fail "Kali $release ($codename) is not officially supported"


### PR DESCRIPTION
1. Added Kali 2.0 Sana recognition and handling, works very well with Trusty packages.
2. Moved apt-transport-https installations into shell function (seems to be really needed in many Debian distros)
3. Changed the tests to allow running script as 'root'. It asks confirmation to run as root. Earlier horrible error message given about running 'random' scripts and exiting is not practical and running random scripts as root vs with 'sudo' is not really worse than with e.g. standard sudoer config on Ubuntu:

```
sudo --list
[sudo] password for XYZ: 
Matching Defaults entries for XYZ on HOST:
    env_reset, mail_badpass,
    secure_path=/usr/local/sbin\:/usr/local/bin\:/usr/sbin\:/usr/bin\:/sbin\:/bin

User XYZ may run the following commands on HOST:
    (ALL : ALL) ALL
```
