### PR TITLE
Make esteid-update-nssdb more universal

### DIFF
--- a/esteid-update-nssdb
+++ b/esteid-update-nssdb
@@ -25,8 +25,9 @@
 NSSDB=$HOME/.pki/nssdb
 MODUTIL="/usr/bin/modutil -force -dbdir sql:$NSSDB"
 CERTUTIL="/usr/bin/certutil -d sql:$NSSDB"
-LIB="/usr/lib/$(gcc -print-multiarch)"
-PKCS_LIB=$LIB/onepin-opensc-pkcs11.so
+CERTS="/usr/share/libdigidoc /usr/share/esteid/certs"
+LIBS=$(ld --verbose | grep SEARCH | awk '{ gsub(/;/,"\n"); print }' | awk -F '\"' '/SEARCH_DIR\(\"=?/ { gsub(/=/,""); print $2 }')
+PKCS11=onepin-opensc-pkcs11.so
 
 if [ ! -f $NSSDB/cert9.db ]; then
     echo "Initializing new database"
@@ -34,22 +35,38 @@ if [ ! -f $NSSDB/cert9.db ]; then
     $CERTUTIL -N --empty-password
 fi
 
-echo "Adding Estonian ID-card certificates"
-$CERTUTIL -A -t ",," -n "ESTEID-SK_2007" -i "/usr/share/libdigidoc/ESTEID-SK 2007.crt"
-$CERTUTIL -A -t ",," -n "ESTEID-SK_2011" -i "/usr/share/libdigidoc/ESTEID-SK 2011.crt"
+for DIR in $CERTS; do
+    if [ -e "$DIR/ESTEID-SK 2007.crt" ]; then
+        for YEAR in 2007 2011 2015; do
+            CERT="$DIR/ESTEID-SK $YEAR.crt"
+            if [ -e "$CERT" ]; then
+                if grep -q ESTEID-SK_$YEAR $NSSDB/cert9.db; then
+                    echo "$CERT already imported"
+                else
+                    echo "Importing $CERT"
+                    PCSCLITE_CSOCK_NAME=/dev/null $CERTUTIL -A -t ",," -n "ESTEID-SK_$YEAR" -i "$CERT"
+                fi
+            else
+                echo "$CERT missing, perhaps Estonian ID-card stack needs updating?"
+            fi
+        done
+    fi
+done
 
-echo "Probing for PKCS#11 library"
-if [ ! -f $PKCS_LIB ]; then
-    echo "No OpenSC installed!"
-    exit 0
-fi
-echo "Found: $PKCS_LIB"
+for DIR in $LIBS; do
+    LIB=$DIR/$PKCS11
+    if [ -f $LIB ]; then
+        echo "Found PKCS#11 library at: $LIB"
+        if grep -q library=$LIB $NSSDB/pkcs11.txt; then
+            echo "ID-card support for Google Chrome/Chromium already enabled"
+        else
+            echo "Enabling ID-card functionality in Google Chrome/Chromium via $LIB"
+            $MODUTIL -delete opensc-pkcs11
+            $MODUTIL -add opensc-pkcs11 -libfile $LIB -mechanisms FRIENDLY
+        fi
+        exit
+    fi
+done
+echo "Can't find $PKCS11"
 
-if grep -q library=$PKCS_LIB $NSSDB/pkcs11.txt; then
-    echo "ID-card support for Google Chrome/Chromium already enabled"
-else
-    # If onepin from OpenSC 0.12.x is present use it
-    echo "Enabling ID-card functionality in Google Chrome/Chromium via $PKCS_LIB"
-    $MODUTIL -delete opensc-pkcs11
-    $MODUTIL -add opensc-pkcs11 -libfile $PKCS_LIB -mechanisms FRIENDLY
-fi
+


### PR DESCRIPTION
Added dynamic lookup for certificates and PKCS#11 libraries, now works on Ubuntu and Fedora both.