### PR TITLE
Eol removal

### DIFF
--- a/install-open-eid.sh
+++ b/install-open-eid.sh
@@ -124,7 +124,7 @@ make_install() {
 
 make_fail() {
   echo -e "$1"
-  exit 3	
+  exit 3
 }
 
 make_warn() {
@@ -145,11 +145,9 @@ test_root
 test_sudo
 
 # 14.04 trusty
-# 14.10 utopic
-# 15.04 vivid
-# 15.10 wily
 # 16.04 xenial
 # 16.10 yakkety
+# 17.04 zesty
 
 # check if Debian or Ubuntu
 distro=`lsb_release -is`

--- a/install-open-eid.sh
+++ b/install-open-eid.sh
@@ -172,9 +172,8 @@ case $distro in
       ;;
    Ubuntu)
       case $codename in
-        utopic|vivid)
-          add_repository $codename
-          instpackage="estonianidcard"
+        utopic|vivid|wily)
+          make_fail "Ubuntu $codename is not officially supported"
           ;;
         *)
           add_repository $codename


### PR DESCRIPTION
Removed end-of-life versions from supported list.
Added an error message when script is being executed on not supported OS versions.