### PR TITLE
Added KDE neon support

### DIFF
--- a/install-open-eid.sh
+++ b/install-open-eid.sh
@@ -170,7 +170,7 @@ case $distro in
           ;;
       esac
       ;;
-   Ubuntu)
+   Ubuntu|neon)
       case $codename in
         utopic|vivid|wily)
           make_fail "Ubuntu $codename is not officially supported"


### PR DESCRIPTION
KDE neon is a software repository which uses the foundation of the latest Ubuntu LTS. Since it uses Ubuntu LTS (xenial) as base but has just different distro name, it acts like default Ubuntu LTS.
Tested on KDE neon user LTS edition and user edition - works like on default Ubuntu LTS
lsb_release -a output: http://i.imgur.com/4iJbWZP.png