### PR TITLE
add to Depends 'qestidutil-tera' as alternative to 'qdigidoc-tera'

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Depends:
  libdigidoc-tools,
  libdigidocpp-tools,
  qdigidoc4,
- qdigidoc-tera,
+ qdigidoc-tera|qestidutil-tera,
  ${misc:Depends}
 Description: This is eID Software metapackage
  This package does not contain anything itself, it's a metapackage that will


### PR DESCRIPTION
The last release in `TeRa` repository offers debian package only for `qestidutil-tera`, which seems to be  renamed to `qdigidoc-tera` in upstream, but does not have official release in github yet.
This patch will allow building all depending packages from latest 'released' status.