### PR TITLE
Add unsupported Debian Buster

### DIFF
--- a/install-open-eid.sh
+++ b/install-open-eid.sh
@@ -134,6 +134,11 @@ case $distro in
       # Debian lacks https support for apt, by default
       sudo apt-get install apt-transport-https
       case "$codename" in
+        buster)
+          make_warn "Debian $codename is not officially supported"
+          make_warn "Installing from ubuntu-bionic repository"
+          add_repository bionic
+          ;;
         *)
           make_fail "Debian $codename is not officially supported"
           ;;


### PR DESCRIPTION
Workaround for installing open-eid in Debian Buster.
Adding bionic repository in case distro is debian and codename is buster.
I also added 2 warnings before adding bionic repository to let user know.  


My distro information is below. Workaround worked fine for me;
PRETTY_NAME="Debian GNU/Linux 10 (buster)"
NAME="Debian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
VERSION_CODENAME=buster
ID=debian

disclaimer: I have not checked included packages in buster. So if bionic updates corresponding packages and buster does not there might be some problems.   
