### PR TITLE
Add support for KDE Neon

### DIFF
--- a/install-open-eid.sh
+++ b/install-open-eid.sh
@@ -143,6 +143,9 @@ case $(echo $distro | tr '[:upper:]' '[:lower:]') in
           ;;
       esac
       ;;
+   neon)
+      make_warn "Neon is not officially supported; assuming that it is equivalent to Ubuntu"
+      ;&
    ubuntu)
       case $codename in
         utopic|vivid|wily|trusty|artful|cosmic|disco|xenial|eoan)


### PR DESCRIPTION
Please refer to the commit message for details.

Tested against a (mostly) fresh install of KDE Neon Focal 20.04 running on an AMD64 machine.