### PR TITLE
Fix apt-key is deprecated warning

### DIFF
--- a/install-open-eid.sh
+++ b/install-open-eid.sh
@@ -65,7 +65,7 @@ add_key() {
   keystring="0xC6C83D68 'RIA Software Signing Key <signing@ria.ee>'"
   echo "Adding key to trusted key set (apt-key add)"
   echo "$keystring"
-  echo "$RIA_KEY" | sudo apt-key add -
+  echo "$RIA_KEY" | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ria-repository.gpg > /dev/null
 }
 
 test_sudo() {

--- a/uninstall-open-eid.sh
+++ b/uninstall-open-eid.sh
@@ -9,5 +9,6 @@ sudo dpkg --purge \
   libdigidocpp-common libdigidocpp-tools libdigidocpp1 \
   qdigidoc4 qdigidoc qesteidutil qdigidoc-tera open-eid
 sudo rm /etc/apt/sources.list.d/ria-repository.list
+sudo rm /etc/apt/trusted.gpg.d/ria-repository.gpg
 sudo apt-key del 592073D4
 sudo apt-key del C6C83D68


### PR DESCRIPTION
Fixes IB-6894, #83

Signed-off-by: Raul Metsma <raul@metsma.ee>