### PR TITLE
General Improvements and Restructuring

### DIFF
--- a/esteid-update-nssdb
+++ b/esteid-update-nssdb
@@ -25,17 +25,18 @@
 PATH="$PATH:/sbin"
 NSSDB=$HOME/.pki/nssdb
 MODUTIL="/usr/bin/modutil -force -dbdir sql:$NSSDB"
-LIBS=$(ldconfig -v 2>/dev/null | grep -v ^$'\t' | sed -e s/:.*$//)
+LIBS=$(/usr/sbin/ldconfig -v 2>/dev/null | /usr/bin/grep -v ^$'\t' | /usr/bin/sed -e s/:.*$//)
 PKCS11=onepin-opensc-pkcs11.so
 
-if [ ! -f $NSSDB/cert9.db ]; then
-    echo "Initializing new database"
-    mkdir -p $NSSDB
+if [ ! -f "$NSSDB"/cert9.db ]; then
+    echo "Initializing new database:"
+    mkdir -p "$NSSDB"
+
 fi
 
 delete_pkcs11() {
-    if $MODUTIL -list $1 2>>/dev/null; then
-        $MODUTIL -delete $1
+    if $MODUTIL -list "$1" 2>>/dev/null; then
+        $MODUTIL -delete "$1"
     fi
 }
 
@@ -43,16 +44,23 @@ delete_pkcs11 "idemia-pkcs11"
 
 for DIR in $LIBS; do
     LIB=$DIR/$PKCS11
-    if [ -f $LIB ]; then
+
+    if [ -f "$LIB" ]; then
         echo "Found PKCS#11 library at: $LIB"
-        if grep -q -s library=$LIB $NSSDB/pkcs11.txt; then
-            echo "ID-card support for Google Chrome/Chromium already enabled"
+
+        if /usr/bin/grep -q -s library="$LIB" "$"NSSDB/pkcs11.txt; then
+            echo "ID-card support for Google Chrome/Chromium is already enabled!"
+
         else
-            echo "Enabling ID-card functionality in Google Chrome/Chromium via $LIB"
+            echo "Enabling ID-card functionality for Google Chrome/Chromium via $LIB:"
             delete_pkcs11 "opensc-pkcs11"
-            $MODUTIL -add opensc-pkcs11 -libfile $LIB -mechanisms FRIENDLY
+            $MODUTIL -add opensc-pkcs11 -libfile "$LIB" -mechanisms FRIENDLY
+
         fi
+
         exit
     fi
+
 done
-echo "Can't find $PKCS11"
+
+echo "Can't find $PKCS11!"

--- a/install-open-eid.sh
+++ b/install-open-eid.sh
@@ -1,233 +1,275 @@
 #!/bin/sh
-# This script configures .deb based Linux repositories
-# License: public domain
-# Script https://github.com/open-eid/linux-installer
-# See wiki https://github.com/open-eid/linux-installer/wiki/Linux-Packages
+# This script configures DigiDoc4 Client (open-eid) for .deb based Linux distributions
+# License:  Public Domain
+# Script:   https://github.com/open-eid/linux-installer
+# Wiki:     https://github.com/open-eid/linux-installer/wiki/Linux-Packages
 set -e
 
-# Key used for signing releases
-RIA_KEY="""-----BEGIN PGP PUBLIC KEY BLOCK-----
-Comment: GPGTools - https://gpgtools.org
+RIA_KEY="https://installer.id.ee/media/install-scripts/C6C83D68.pub"
+SUDO="/usr/bin/sudo"
 
-mQINBFcrMk4BEADCimHCTTCsBbUL+MtrRGNKEo/ccdjv0hArPqn1yt/7w9BFH17f
-kY+w6IFdfD0o1Uc7MOofsF3ROVIsw/mul6k1YUh2HxtKmsVOMLE0eWHShvMlXKDV
-1H1dCAk3A2c7nmzTedJaMMu+cLCRpt9zpmF1kG4i07UuyBxpRmolq/+hYa2JHPw4
-CFDW0s1T/rF1KUTbGHQKhT9Qek2tTsHQn4C33QUnCMkb3HCbDQksW69FoLiwa3am
-fAgGSOI8iZ3uofh3LU9kEy6dL6ZFKUevOETlDidHaNNDhC8g0seMkMLTuSmWc64X
-DTobStcuZcHtakzeWZ/V2kXouhUsgXOMxhPGHFkfd+qqk3LGqZ29wTK2bYyTjCsD
-gYPO2YHGmCzLzH9DgHNfjDWzeAWClg5PO/oB5sg5fYMwmHJtLeqGJarFKl22p9/K
-odRruGQiGqkHptxwdoNjgvgluiSb6C+dCU5pGU8t+9/+IfqxChltUkI02O6jfPO4
-mweflYBQ8zkXOLPlVIfJnO5xw4wwrh3rV/fXxlNMI+Ni7/zPF61OQ50r/oya6zRR
-rSLEAig2lZY+vhbv9WDgJKIPwb8oe13d1UCRDdtkj70MBQFh1m6RFzDXy4821U9w
-TRtRy+92UN5jRRkeMb0yaO/EboTRjOy7BToJSVeYGRQy73M2vhxhWXSXrwARAQAB
-tClSSUEgU29mdHdhcmUgU2lnbmluZyBLZXkgPHNpZ25pbmdAcmlhLmVlPokCNwQT
-AQoAIQUCVysyTgIbAwULCQgHAwUVCgkICwUWAgMBAAIeAQIXgAAKCRDpqyFNxsg9
-aJJ9D/sGXNgFsEvbGEYlKtrhY9ungOBk7B5iH/Nxy+yMjIZY9mLdp9RMEO6oZFam
-3vC+3o01veRUkf0KRDjtDAK2c358aHsNAVcFXfJk950OuqUzywZvuNwlCOMCYZ41
-KBUfcwebhqiqMDzOLnx2mwUvV0OQGKgpqQes1+LE0pI2ySsgUyTp50mvLt8e9yXq
-1uO82WzmAYcR8VGOViavjtV8ZF4X09d1ugZAWeOsZHdjl7Yb/aUy4WW35wQsHmo8
-Tro6KuG9KgvrNM798gdhwA6kt29B2YGGTQGODwIt8jydN2o0P3UhpVW+C+60Axqw
-jSnPOJFPNVsRJ5se9PvhJS0xmUVOttRJFU74FmsK4dArG4pqMjBzXReEk9Pz03FW
-9EbD8PY+n/hrp2zp7kEa5umzLJePi3117r06OkiQoI0Wfmi3bISBe0oN2lS7QUBo
-DUursJNSMKpEhQBc3lPsyKoZwb73fl86iOm5/GpdMkKBXOQzGbgJV96I+s6ZemQ4
-psbxQCWStcwLnenkKEU2eezP9codmtRivRftx9+/xt9DxIfbtvZMPsrG6+EI+Ovo
-onO6lMgnQJmxhjJ5FUwyBn27b41LDUnQhdMHtSwr7HCyU/ufnte1dQQy+xxYH4fG
-oafemhM54Tx0fi47HruFu+DjSLECP57TVAVFJTyn6wr4U2Lya7kCDQRXKzJOARAA
-q1I36MBmlWenlq9ZqwAvA0kT1l4uyrkj7EIpPXNmkkMYtW3jHWe/4M4k6b0NmNnj
-FoaPmK86b037AoODd40xQYWV3Y5arwSfcZPYx35/+uiim4vykNI7u9MMujHDvMvV
-AE2RXK/s1Lj+7B37H9AkcpAdj+YngYEKrVjzUbiPJXisbEc/g94F56YqbnGB1g6Y
-pMXSGC1SvaYCBnUyWzLlmHYlib36R3dWXmpuQuTTn65QQU1jIKm5na7c37AP6k7G
-RBthPmDveXV+UFlWBl3ybqhVcf7svGcSLf/n7ekF9PlUEDoQ+4rA+mQARS138R3I
-WbZAB7KOTBrLPpPvKXvbq5r1/wfArBbKxOiB7c4xlejqeRbXFig4acQHK7vDfrIG
-yA6hyR1H73kp3uFl0SEa/RKsPcYUagkFn3tlUBrX+6/ZuOcowaN9FuShJlMrgk1K
-DiPprE7+gwA1fnGo6X/Jto6M6xkeGf0Lj2YZ6B0u2x8BIwSJUDqISd2TJoireMBb
-0GQRUyfBDGB9ZDvMvC0SIezw3aEPW68uLadJa98QUGyYWQunIfiKfGzKHhpc4ser
-V28WIJ/QJf2oJ3Cp3Ot2DI4qgJbSPkQYcizK/dNXJ6KoUv95i5SEQ82tw0vsytmI
-3jZseGWLOnz9+LS41O55JjylDUAgJchroNF7bJZ2DocAEQEAAYkCHwQYAQoACQUC
-VysyTgIbDAAKCRDpqyFNxsg9aKrtD/wM9pDDvLeeA6fg5mmAb6dmfhr2hAecbI/n
-sGD5qslu0oE11Zj9gwYD5ixhieLbudEWk+YaGsg1/s1vMIEZsAXQYY0kihOBYGtr
-heFA7YPzJSac1uwlF+unb7wvW8zYbyjkDpBmuyA08fHOFisHp1A4v4zsaLKZbCy7
-qQJWk8JU7eJnGecAuKnF8Zqpxur2k17QlsaoA3DIUDiSJyQVsFgTAgSkzjdQYVH2
-LVsb3XZeJnOoV1fs0E6kCCDUXtVx2yVzRgLKNnZvbufTKRAjr+mggUH+JOBbrDf/
-zf9Ud8PHBaLJh9+OA3AO310FwiJX0SnZjcCg29C7N0SkuDWowDLjwT8XAikdAsRC
-xPZcOJSQjnSrd/X6ZjvDEBNlnY0dBOnuWt3CmwEdIreEJGomGMBE2/mw5ieFhlpN
-6pp4Oe8kLl3mpd11RxfY2wW2r1BkxihtV/4pts7kCgSyRb8DwSZVYDHai5OtfeMZ
-OTbaIP5/7aWoxd3R4JoKX5zHqY6slzi+MERJmDcIR5v1Np8HGJIHR/10uG3WvQ43
-CBVNV1KxDSWiO99+50ajU2humchuZKucVQUirUGd5ZPijAuZzrQeE9yboEMSB5nj
-WxoE6tFHd17wOg+ImAMerVY53I4h0EkmbzPfeszZYR0geGvu4sngt69wJmmTINUC
-K2czbpReKw==
-=aSyh
------END PGP PUBLIC KEY BLOCK-----
-"""
+install_dependencies() {
+    echo "Ensuring that wget and gpg are installed on the host (sudo apt update && sudo apt install gpg wget):"
+    echo "This is required to add RIA's key to the trusted key set."
+    echo
+
+    $SUDO /usr/bin/apt-get update
+    $SUDO /usr/bin/apt-get install -y gpg wget
+}
 
 add_key() {
-  # keystring=`echo "$RIA_KEY" | gpg` # XXX: can't be automated, gpg always creates files on disk
-  keystring="0xC6C83D68 'RIA Software Signing Key <signing@ria.ee>'"
-  echo "Adding key to trusted key set"
-  echo "$keystring"
-  echo "$RIA_KEY" | gpg --dearmor | sudo tee /usr/share/keyrings/ria-repository.gpg > /dev/null
+    echo "Adding RIA's key to the trusted key set (/usr/share/keyrings/ria-repository.gpg)"
+    echo
+
+    # This is better than the old method - less of an eyesore.
+    /usr/bin/wget -O- -q $RIA_KEY | /usr/bin/gpg --dearmor | $SUDO /usr/bin/tee /usr/share/keyrings/ria-repository.gpg > /dev/null
 }
 
-test_sudo() {
-  if ! command -v sudo>/dev/null; then
-     make_fail "You must have sudo and be in sudo group\nAs root do: apt install sudo && adduser $USER sudo"
-  fi
+check_root() {
+    if [ "$(/usr/bin/whoami)" != "root" ]; then
+        if ! which $SUDO >/dev/null; then
+            make_fail "This script requires root privileges, thus sudo must be installed on the system and the $USER must be in the sudoers group\nThis can be achieved by running the following command as root: apt install sudo && adduser $USER sudo"
+
+        fi
+
+    else
+        # We're already root:
+        SUDO=""
+
+    fi
 }
 
-test_root() {
-  if test $(id -u) -eq 0; then
-    echo "You run this script as root. DO NOT RUN RANDOM SCRIPTS AS ROOT."
-    exit 2
-  fi
-}
-
-# add the given repository into /etc/apt/sources.list.d
+# Add the given repository into /etc/apt/sources.list.d:
 add_repository() {
-  umask 0022
-  echo "Adding RIA repository to APT sources list (/etc/apt/sources.list.d/ria-repository.list)"
-  echo "deb [signed-by=/usr/share/keyrings/ria-repository.gpg] https://installer.id.ee/media/ubuntu/ $1 main" | sudo tee /etc/apt/sources.list.d/ria-repository.list
+    umask 0022
+    echo "Adding RIA's repository to APT sources list (/etc/apt/sources.list.d/ria-repository.list):"
+    echo
+
+    echo "deb [signed-by=/usr/share/keyrings/ria-repository.gpg] https://installer.id.ee/media/ubuntu/ $1 main" | $SUDO /usr/bin/tee /etc/apt/sources.list.d/ria-repository.list
+    echo
 }
 
 make_install() {
-  echo "Installing software (apt update && apt install open-eid)"
-  sudo apt update
-  sudo apt install opensc "$@"
-  echo "Enabling PCSCD service!"
-  sudo systemctl enable pcscd.socket
-  sudo systemctl start pcscd.socket
+    echo "Installing DigiDoc4 (sudo apt update && sudo apt install open-eid)"
+    echo
+
+    $SUDO /usr/bin/apt-get update
+    $SUDO /usr/bin/apt-get install -y opensc open-eid
+
+    echo "Enabling PCSCD service:"
+    echo
+
+    # Enable and start the service:
+    $SUDO /usr/bin/systemctl enable --now pcscd.socket
 }
 
 make_fail() {
-  echo "$1"
-  exit 3
+    echo "$1"
+    exit 3
 }
 
 make_warn() {
-  echo "### $1"
-  echo "Press ENTER to continue, CTRL-C to cancel"
-  read -r dummy
+    echo "### $1"
+    echo "Press ENTER to continue, CTRL-C to cancel"
+    read -r dummy
 }
 
 ### Install Estonian ID card software
+# Check for Debian derivative.
+if ! command -v /usr/bin/lsb_release >/dev/null; then
+    make_fail "# Not a Debian/Ubuntu/Kali Linux :("
 
-# check for Debian derivative.
-if ! command -v lsb_release>/dev/null; then
-  make_fail "# Not a Debian Linux :("
 fi
 
-# we use sudo
-test_root
-test_sudo
+# This script requires root (via sudo):
+check_root
 
-# version   name    LTS   supported until
-# 20.04     focal   LTS   2025-04
-# 22.04     jammy   LTS   2027-04
-# 23.04     lunar   -   2024-01
-# 23.10     mantic   -   2024-07
-LATEST_SUPPORTED_UBUNTU_CODENAME='mantic'
+# Install dependencies:
+install_dependencies
 
-# check if Debian or Ubuntu
-distro=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
-release=$(lsb_release -rs)
-codename=$(lsb_release -cs)
+# Version   Codename    LTS Supported Until
+# 20.04     focal       LTS 2025-04
+# 22.04     jammy       LTS 2027-04
+# 22.10     kinetic     -   2023-07
+# 23.04     lunar       -   2024-01
+LATEST_SUPPORTED_UBUNTU_CODENAME='lunar'
 
-case $distro in
-   debian)
-      make_warn "Debian is not officially supported"
-      echo "### Installing possibly missing https support for APT (apt install apt-transport-https)"
-      # Debian lacks https support for apt, by default
-      sudo apt install apt-transport-https
-      case "$codename" in
-         bullseye)
-          make_warn "Debian $codename is not officially supported"
-          make_warn "Installing from ubuntu-focal repository"
-          add_repository focal
-          ;;
-         bookworm)
-	 	      make_warn "Debian $codename is not officially supported"
-	 	      make_warn "Installing from ubuntu-jammy repository"
-	 	      add_repository jammy
-	 	      ;;
-        *)
-          make_fail "Debian $codename is not officially supported"
-          ;;
+# Gather OS info:
+DISTRO=$(/usr/bin/lsb_release -is 2>/dev/null | /usr/bin/tr '[:upper:]' '[:lower:]')    # Outputs the distribution name (without "No LSB modules are available." warning) in lowercase
+CODENAME=$(/usr/bin/lsb_release -cs 2>/dev/null)                                        # Outputs the codename info (without "No LSB modules are available." warning)
+RELEASE=$(/usr/bin/lsb_release -rs 2>/dev/null)                                         # Outputs the release info (without "No LSB modules are available." warning)
+
+case $DISTRO in
+    debian | kali)
+        # The warning is "generic" to ensure it covers both Debian and Kali:
+        make_warn "$(/usr/bin/lsb_release -ds 2>/dev/null) is not officially supported!"
+        echo "### Installing possibly missing https support for apt (apt install apt-transport-https)"
+        echo
+
+        # By default, Debian lacks https support for apt:
+        $SUDO /usr/bin/apt-get install -y apt-transport-https
+
+        case "$CODENAME" in
+            bullseye)
+                make_warn "Debian Bullseye is not officially supported!"
+                make_warn "Installing from ubuntu-focal repository:"
+                add_repository focal
+
+                ;;
+
+            bookworm)
+	 	        make_warn "Debian Bookworm is not officially supported!"
+	 	        make_warn "Installing from ubuntu-kinetic repository:"
+	 	        add_repository kinetic
+
+	 	        ;;
+
+            kali-rolling)
+                make_warn "$(/usr/bin/lsb_release -ds 2>/dev/null) is not officially supported!"
+
+                # Current version of Kali (2023.4) can use the same repos as Debian Bookworm.
+                make_warn "Installing from ubuntu-kinetic repository:"
+                add_repository kinetic
+
+                ;;
+
+            *)
+                make_fail "Debian $CODENAME is not officially supported!"
+
+                ;;
+
+        esac
+
+        ;;
+
+    ubuntu | neon)
+        case $DISTRO in
+            neon)
+                make_warn "Neon is not officially supported; assuming that it is equivalent to Ubuntu."
+
+                ;;
+
+            *)
+                ;;
+
+        esac
+
+        case $CODENAME in
+            utopic | vivid | wily | trusty | artful | cosmic | disco | xenial | eoan | groovy | hirsute | impish | bionic)
+                make_fail "Ubuntu $CODENAME is not officially supported!"
+
+                ;;
+
+            focal | jammy | kinetic | lunar)
+                add_repository "$CODENAME"
+
+                ;;
+
+            *)
+                make_warn "Ubuntu $CODENAME is not officially supported!"
+                make_warn "Trying to install package for Ubuntu ${LATEST_SUPPORTED_UBUNTU_CODENAME}:"
+                add_repository ${LATEST_SUPPORTED_UBUNTU_CODENAME}
+
+                ;;
+
+        esac
+
+        ;;
+
+    linuxmint)
+        case $RELEASE in
+            21*)
+                make_warn "Linux Mint 21 is not officially supported!"
+                make_warn "Installing from ubuntu-jammy repository:"
+                add_repository jammy
+
+                ;;
+
+            20*)
+                make_warn "Linux Mint 20 is not officially supported"
+                make_warn "Installing from ubuntu-focal repository:"
+                add_repository focal
+
+                ;;
+
+            *)
+                make_fail "Linux Mint $RELEASE is not officially supported"
+
+                ;;
+
+        esac
+
+        ;;
+
+    elementary*os | elementary)
+        case $RELEASE in
+            7*)
+                make_warn "Elementary OS 7 is not officially supported!"
+                make_warn "Installing from ubuntu-jammy repository:"
+                add_repository jammy
+
+                ;;
+
+            *)
+                make_fail "Elementary OS $RELEASE is not officially supported!"
+
+                ;;
+
+        esac
+
+        ;;
+
+    pop)
+        case $CODENAME in
+            artful | cosmic | disco | eoan | bionic)
+                make_fail "Pop!_OS $CODENAME is not officially supported!"
+
+                ;;
+
+            focal | jammy)
+                make_warn "Pop!_OS $CODENAME is not officially supported!"
+
+                # Can't find a good solution to run nested code-evals within the statement below.
+                # But since $CODENAME is already defined in a safe manner, this shouldn't be too problematic.
+                make_warn "Installing from ubuntu-$(echo $CODENAME | /usr/bin/tr '[:upper:]' '[:lower:]') repository:"
+                add_repository "$CODENAME"
+
+                ;;
+
+            *)
+                make_warn "Pop!_OS $CODENAME is not officially supported!"
+                make_warn "Trying to install package for Pop!_OS ${LATEST_SUPPORTED_UBUNTU_CODENAME}:"
+                add_repository ${LATEST_SUPPORTED_UBUNTU_CODENAME}
+
+                ;;
+
       esac
+
       ;;
-   ubuntu|neon|zorin)
-      case $distro in
-         neon) make_warn "Neon is not officially supported; assuming that it is equivalent to Ubuntu" ;;
-         *) ;;
-      esac
-      case $codename in
-        utopic|vivid|wily|trusty|artful|cosmic|disco|xenial|eoan|groovy|hirsute|impish|bionic|zorin|kinetic)
-          make_fail "Ubuntu $codename is not officially supported"
-          ;;
-        focal|jammy|lunar|mantic)
-          add_repository $codename
-          ;;
-        *)
-          make_warn "Ubuntu $codename is not officially supported"
-          make_warn "Trying to install package for Ubuntu ${LATEST_SUPPORTED_UBUNTU_CODENAME}"
-          add_repository ${LATEST_SUPPORTED_UBUNTU_CODENAME}
-          ;;
-      esac
-      ;;
-   linuxmint)
-      case $release in
-        21*)
-          make_warn "Linux Mint 21 is not officially supported"
-          add_repository jammy
-          ;;
-        20*)
-          make_warn "Linux Mint 20 is not officially supported"
-          add_repository focal
-          ;;
-        *)
-          make_fail "Linux Mint $release is not officially supported"
-          ;;
-      esac
-      ;;
-   elementary*os|elementary)
-      case $release in
-        7*)
-          make_warn "Elementary OS 7 is not officially supported"
-          add_repository jammy
-          ;;
-        *)
-          make_fail "Elementary OS $release is not officially supported"
-          ;;
-      esac
-      ;;
-   pop)
-      case $codename in
-        artful|cosmic|disco|eoan|bionic)
-          make_fail "Pop!_OS $codename is not officially supported"
-          ;;
-        focal|jammy)
-          make_warn "Pop!_OS $codename is not officially supported"
-          add_repository $codename
-          ;;
-        *)
-          make_warn "Pop!_OS $codename is not officially supported"
-          make_warn "Trying to install package for Pop!_OS ${LATEST_SUPPORTED_UBUNTU_CODENAME}"
-          add_repository ${LATEST_SUPPORTED_UBUNTU_CODENAME}
-          ;;
-      esac
-      ;;
-   *)
-      make_fail "$distro is not supported :("
-      ;;
+
+    *)
+        make_fail "$DISTRO is not supported :("
+
+        ;;
+
 esac
 
 add_key
-make_install open-eid
+make_install
 
-# Configure Chrome PKCS11 driver for current user, /etc/xdg/autstart/ will init other users on next logon
-/usr/bin/esteid-update-nssdb
-echo 
-echo "Thank you for using Estonian ID card!"
-read -p "Would you like to read instructions on how to configure browsers for using ID-card? (Y/n): " instructions
+# Configure Chrome PKCS11 driver for the current user, /etc/xdg/autstart/ will init other users' driver on next logon:
+$SUDO /usr/bin/esteid-update-nssdb
+echo
+echo "Thank you for using your Estonian ID card!"
+read -p "Would you like to read instructions on how to configure your browsers to use your ID-card? (Y/n): " instructions
+
 case $instructions in
-    [Yy]*|"" ) xdg-open "https://www.id.ee/en/article/ubuntu-id-software-installation-updating-and-removal/#removing-mozilla-firefox";;
-    * ) ;;
+    [Yy]*|"" )
+        /usr/bin/xdg-open "https://www.id.ee/en/article/ubuntu-id-software-installation-updating-and-removal/#removing-mozilla-firefox"
+
+        ;;
+
+    * )
+        ;;
+
 esac

--- a/uninstall-open-eid.sh
+++ b/uninstall-open-eid.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
-# This script removes open-eid .deb packages
+# This script removes DigiDoc4 Client (open-eid) packages
 
-sudo dpkg --purge \
-  opensc opensc-pkcs11 awp \
-  chrome-token-signing chrome-token-signing-policy firefox-pkcs11-loader \
-  token-signing-native token-signing-chrome token-signing-firefox \
-  web-eid web-eid-native web-eid-chrome web-eid-firefox \
-  libdigidoc-common libdigidoc-tools libdigidoc2 \
-  libdigidocpp-common libdigidocpp-tools libdigidocpp1 \
-  qdigidoc4 qdigidoc qesteidutil qdigidoc-tera open-eid
-sudo rm /etc/apt/sources.list.d/ria-repository.list
-sudo rm /etc/apt/trusted.gpg.d/ria-repository.gpg
-sudo rm /usr/share/keyrings/ria-repository.gpg
-sudo apt-key del 592073D4
-sudo apt-key del C6C83D68
+# Delete open-eid and opensc (and their dependencies):
+/usr/bin/sudo /usr/bin/dpkg --purge \
+    awp chrome-token-signing chrome-token-signing-policy \
+    firefox-pkcs11-loader libdigidoc-common libdigidoc-tools \
+    libdigidoc2 libdigidocpp-common libdigidocpp-tools libdigidocpp1 \
+    open-eid opensc opensc-pkcs11 qdigidoc qdigidoc-tera qdigidoc4 \
+    qesteidutil token-signing-chrome token-signing-firefox token-signing-native \
+    web-eid web-eid-chrome web-eid-firefox web-eid-native
+
+# Remove ria-repository.list from /etc/apt/sources.list.d/:
+/usr/bin/sudo rm /etc/apt/sources.list.d/ria-repository.list
+
+# Remove RIA's key from the trusted key set:
+/usr/bin/sudo rm /etc/apt/trusted.gpg.d/ria-repository.gpg
+/usr/bin/sudo rm /usr/share/keyrings/ria-repository.gpg
+/usr/bin/sudo /usr/bin/apt-key del C6C83D68


### PR DESCRIPTION
I have performed several improvements that were needed as I tried to get DigiDoc4 to work on my Kali Linux when I was addressing https://github.com/open-eid/DigiDoc4-Client/issues/1215. This called for an "overhaul" of `install-open-eid.sh`. However, I noticed minor issues in `uninstall-open-eid.sh` and `esteid-update-nssdb` as well, which I have addressed.

A general overview of the changes would be the following:
- Add a better way of getting RIA's key in `install-open-eid.sh`
- Implement sudo instead of direct root usage (especially in `install-open-eid.sh`)
- Use absolute paths instead of relative paths (Across all 3 scripts)
- Add Kali Linux support in `install-open-eid.sh`
- Formatting and readability improvements (Across all 3 scripts)

Signed-off-by: Arslan Masood (contact@arszilla.com)