### PR TITLE
Remove obsolete firefox-pkcs11-loader dependency.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,20 +12,19 @@ jobs:
       DEBEMAIL: 'github-actions@github.com'
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install dependencies
-      run: sudo apt-get update -qq && sudo apt-get install -y dh-make dpkg-dev devscripts fakeroot lintian
+      run: sudo apt update -qq && sudo apt install --no-install-recommends -y debhelper dpkg-dev devscripts lintian
     - name: Build
       run: |
         VERSION=$(date '+%y.%m.0.0')
-        dh_make --createorig --addmissing --defaultless -y -p open-eid_${VERSION}
-        dch --distribution `lsb_release -cs` -b -v ${VERSION} 'Release'
-        dpkg-buildpackage -rfakeroot -us -uc
+        dch --distribution `lsb_release -cs` -b -v ${VERSION} "Release ${VERSION}"
+        dpkg-buildpackage -us -uc
         mv ../open-eid* .
     - name: Lintian
       run: lintian *.deb
     - name: Archive artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: deb
         path: ./*.deb

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ A metapackage for Ubuntu/Debian based distributions.
 
 2. Build
 
-        dh_make --createorig --addmissing --defaultless -y -p open-eid_18.6.0.0
         dch --distribution unstable -v 18.6.0.0 'Release'
         dpkg-buildpackage -rfakeroot -us -uc
 

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,6 @@ Homepage: https://www.ria.ee
 Package: open-eid
 Architecture: all
 Depends:
- firefox-pkcs11-loader,
  web-eid,
  qdigidoc4,
  libnss3-tools,
@@ -21,7 +20,6 @@ Description: This is eID Software metapackage
  This package does not contain anything itself, it's a metapackage that will
  pull in packages required for using the eID Software on the desktop:
  .
- firefox-pkcs11-loader - Firefox PKCS#11 module loader
  web-eid - new Chrome / Firefox digital signature plugin
  qdigidoc4 - Estonian digital signing and ID card management application
  .


### PR DESCRIPTION
IB-7998

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/open-eid/.github/blob/master/CONTRIBUTING.md!
-->

Signed-off-by: Raul Metsma <raul@metsma.ee>
