### PR TITLE
Add Arch Linux support to install-open-eid.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,25 @@ A metapackage for Ubuntu/Debian based distributions.
 
         https://installer.id.ee/media/install-scripts/install-open-eid.sh
 
+## Arch Linux (community-supported)
+
+The helper script also supports Arch Linux and Arch-family derivatives
+(Manjaro, EndeavourOS, CachyOS, Garuda). When run on those systems it
+installs the Estonian eID stack via `pacman` and an AUR helper
+(`yay`, `paru`, `pikaur` or `trizen` — whichever is available):
+
+- **pacman:** `opensc`, `pcsclite`, `ccid`, `pcsc-tools`
+- **AUR:** `qdigidoc4`, `web-eid-native`, `web-eid-chrome`, `web-eid-firefox`
+
+The `pcscd.socket` smartcard daemon is enabled, and the OpenSC PKCS#11
+module is available at `/usr/lib/opensc-pkcs11.so` for Firefox; the
+Chrome / Chromium / Edge native messaging host is registered
+automatically.
+
+This path uses community-maintained AUR packages and is not part of the
+officially supported distributions listed at
+[id.ee](https://www.id.ee/en/article/install-id-software/).
+
 ## Support
 Official builds are provided through official distribution point [id.ee](https://www.id.ee/en/article/install-id-software/). If you want support, you need to be using official builds. Contact our support via [www.id.ee](http://www.id.ee) for assistance.
 

--- a/install-open-eid.sh
+++ b/install-open-eid.sh
@@ -105,7 +105,52 @@ make_warn() {
   read -r dummy
 }
 
+# Arch Linux: install the Estonian ID-card stack from the official repos
+# (opensc/pcsclite/ccid/pcsc-tools) and from the AUR (qdigidoc4 and the
+# web-eid native messaging host + browser helpers).
+arch_install() {
+  echo "### Detected Arch Linux (or derivative)"
+  aur_helper=""
+  for h in yay paru pikaur trizen; do
+    if command -v "$h" >/dev/null 2>&1; then
+      aur_helper="$h"
+      break
+    fi
+  done
+  if [ -z "$aur_helper" ]; then
+    make_fail "An AUR helper (yay, paru, pikaur or trizen) is required to install qdigidoc4 and web-eid from the AUR.\nInstall one and re-run this script."
+  fi
+  echo "Using AUR helper: $aur_helper"
+  echo "### Installing smartcard middleware from official Arch repositories"
+  sudo pacman -S --needed --noconfirm opensc pcsclite ccid pcsc-tools
+  echo "### Installing Estonian eID applications from the AUR"
+  "$aur_helper" -S --needed qdigidoc4 web-eid-native web-eid-chrome web-eid-firefox
+  echo "### Enabling the pcscd smartcard daemon"
+  sudo systemctl enable --now pcscd.socket
+  echo
+  echo "PKCS#11 module installed at /usr/lib/opensc-pkcs11.so"
+  echo "Firefox: Preferences -> Privacy & Security -> Security Devices -> Load (module: /usr/lib/opensc-pkcs11.so)"
+  echo "Chrome/Chromium/Edge: native messaging host registered automatically; install the Web eID extension."
+  echo
+  echo "Thank you for using Estonian ID card!"
+  exit 0
+}
+
 ### Install Estonian ID card software
+
+# Arch Linux support (additive; falls through to the Debian/Ubuntu flow on
+# every other distribution).
+if [ -r /etc/os-release ]; then
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  case " ${ID:-} ${ID_LIKE:-} " in
+    *" arch "*|*" archlinux "*|*" manjaro "*|*" endeavouros "*|*" cachyos "*|*" garuda "*)
+      test_root
+      test_sudo
+      arch_install
+      ;;
+  esac
+fi
 
 # check for Debian derivative.
 if ! command -v lsb_release>/dev/null; then


### PR DESCRIPTION
Detect Arch Linux (and the common derivatives Manjaro, EndeavourOS, CachyOS and Garuda) via /etc/os-release before the existing lsb_release-based check, and install the Estonian eID stack via pacman plus an AUR helper:

  pacman: opensc, pcsclite, ccid, pcsc-tools
  AUR:    qdigidoc4, web-eid-native, web-eid-chrome, web-eid-firefox

The pcscd smartcard daemon socket is enabled, and a short post-install message points the user at the OpenSC PKCS#11 module for Firefox and at the auto-registered native messaging host for Chrome/Chromium/Edge.

The change is purely additive: when /etc/os-release does not identify an Arch-family distribution the script falls through to the unchanged Debian/Ubuntu flow.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/open-eid/.github/blob/master/CONTRIBUTING.md!
-->